### PR TITLE
[ASL-5061] update all core and theme to @qubic-js version

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,8 +21,8 @@
       }
     },
     "import/core-modules": [
-      "@react-native-cask-ui/core",
-      "@react-native-cask-ui/theme"
+      "@qubic-js/react-native-cask-ui-core",
+      "@qubic-js/react-native-cask-ui-theme"
     ]
   },
   "rules": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,6 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@react-native-cask-ui/theme": "^1.0.3",
     "react-content-loader": "^5.1.2",
     "react-native-draggable-flatlist": "^1.1.9",
     "react-native-safe-area-context": "4.4.1",
@@ -23,7 +22,8 @@
     "react-native-svg-web": "^1.0.9",
     "react-native-tab-view": "2.14.3",
     "react-navigation-header-buttons": "^3.0.1",
-    "utility-types": "^3.10.0"
+    "utility-types": "^3.10.0",
+    "@qubic-js/react-native-cask-ui-theme": "^1.2.2"
   },
   "devDependencies": {
     "@types/react": "^16.9.49",

--- a/packages/core/src/ui-next/Button.tsx
+++ b/packages/core/src/ui-next/Button.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { StyleSheet, TouchableOpacity, View, Text } from 'react-native';
-import { useOverride, useTheme } from '@react-native-cask-ui/theme';
+import { useOverride, useTheme } from '@qubic-js/react-native-cask-ui-theme';
 import { $Diff } from 'utility-types';
 
 import type { TouchableOpacityProps, ViewStyle, TextStyle, ImageStyle } from 'react-native';

--- a/packages/core/src/ui/Badge.tsx
+++ b/packages/core/src/ui/Badge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
-import { useOverride, useMemoStyles, TColor } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/Button.tsx
+++ b/packages/core/src/ui/Button.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { StyleSheet, TouchableOpacity, View, Text, TouchableOpacityProps } from 'react-native';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 import { $Diff } from 'utility-types';
 
 const defaultStyles = StyleSheet.create({

--- a/packages/core/src/ui/Card.tsx
+++ b/packages/core/src/ui/Card.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/Flex.tsx
+++ b/packages/core/src/ui/Flex.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { View, FlexAlignType, DimensionValue } from 'react-native';
-import { TColor, useMemoStyles } from '@react-native-cask-ui/theme';
+import { TColor, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 type JustifyContentType = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
 

--- a/packages/core/src/ui/HeaderButtons.tsx
+++ b/packages/core/src/ui/HeaderButtons.tsx
@@ -5,7 +5,7 @@ import {
   HeaderItemProps,
 } from 'react-navigation-header-buttons';
 import EvilIcons from 'react-native-vector-icons/EvilIcons';
-import { useOverride } from '@react-native-cask-ui/theme';
+import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
 
 export type HeaderButtonsItemProps = {
   variant?: string;

--- a/packages/core/src/ui/Image.tsx
+++ b/packages/core/src/ui/Image.tsx
@@ -12,7 +12,7 @@ import {
 import ContentLoader from 'react-content-loader';
 import { Path } from 'react-native-svg';
 // import * as Progress from 'react-native-progress';
-import { useOverride, useMemoStyles, TColor } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
 import { $Diff } from 'utility-types';
 
 const defaultStyles = StyleSheet.create({

--- a/packages/core/src/ui/InputSpinner.tsx
+++ b/packages/core/src/ui/InputSpinner.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback } from 'react';
 import { StyleSheet, View, TouchableOpacity, Text } from 'react-native';
 import EvilIcons from 'react-native-vector-icons/EvilIcons';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/List.tsx
+++ b/packages/core/src/ui/List.tsx
@@ -11,7 +11,7 @@ import {
   VirtualizedListWithoutRenderItemProps,
 } from 'react-native';
 import DraggableFlatList, { OnMoveEndInfo } from 'react-native-draggable-flatlist';
-import { useOverride, TStyle } from '@react-native-cask-ui/theme';
+import { useOverride, TStyle } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   defaultHeaderPlaceholder: {

--- a/packages/core/src/ui/ListItem.tsx
+++ b/packages/core/src/ui/ListItem.tsx
@@ -13,7 +13,7 @@ import {
   KeyboardTypeOptions,
 } from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import { useOverride, useMemoStyles, TColor } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
 
 import DisclosureIndicator from '../svg/DisclosureIndicator';
 

--- a/packages/core/src/ui/LoadingSpinner/LoadingSpinnerRenderer.tsx
+++ b/packages/core/src/ui/LoadingSpinner/LoadingSpinnerRenderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, Text, ActivityIndicator } from 'react-native';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 import { LoadingSpinnerRendererProps } from './types';
 

--- a/packages/core/src/ui/LoadingSpinner/types.ts
+++ b/packages/core/src/ui/LoadingSpinner/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react';
-import { TColor } from '@react-native-cask-ui/theme';
+import { TColor } from '@qubic-js/react-native-cask-ui-theme';
 
 type BaseProps = {
   variant?: string;

--- a/packages/core/src/ui/Modal.tsx
+++ b/packages/core/src/ui/Modal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { StyleSheet, View, Modal, TouchableWithoutFeedback, NativeSyntheticEvent } from 'react-native';
-import { useOverride } from '@react-native-cask-ui/theme';
+import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   backdrop: {

--- a/packages/core/src/ui/Pager.tsx
+++ b/packages/core/src/ui/Pager.tsx
@@ -11,7 +11,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { TabView, TabBar, Pager, SceneRendererProps } from 'react-native-tab-view';
-import { useOverride } from '@react-native-cask-ui/theme';
+import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
 
 import PagerConfig from './PagerConfig';
 

--- a/packages/core/src/ui/Rating.tsx
+++ b/packages/core/src/ui/Rating.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/ReadMore.tsx
+++ b/packages/core/src/ui/ReadMore.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, ReactNode } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 const fixedStyles = StyleSheet.create({
   hidden: {

--- a/packages/core/src/ui/Screen.tsx
+++ b/packages/core/src/ui/Screen.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useMemo } from 'react';
 import { StyleSheet, View, StatusBar, StatusBarStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useOverride, useMemoStyles, TStyle } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles, TStyle } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/SearchBar/SearchBarRenderer.ios.tsx
+++ b/packages/core/src/ui/SearchBar/SearchBarRenderer.ios.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Text, TextInput, TouchableOpacity } from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 import { TSearchBarRendererProps } from './types';
 

--- a/packages/core/src/ui/SearchBar/SearchBarRenderer.tsx
+++ b/packages/core/src/ui/SearchBar/SearchBarRenderer.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { StyleSheet, View, TextInput, TouchableOpacity } from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 import { TSearchBarRendererProps } from './types';
 

--- a/packages/core/src/ui/SearchBar/types.ts
+++ b/packages/core/src/ui/SearchBar/types.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react';
 import { KeyboardTypeOptions, NativeSyntheticEvent, TextInputFocusEventData } from 'react-native';
 
-import { TColor } from '@react-native-cask-ui/theme';
+import { TColor } from '@qubic-js/react-native-cask-ui-theme';
 
 type BaseProps = {
   variant?: string;

--- a/packages/core/src/ui/Separator.tsx
+++ b/packages/core/src/ui/Separator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/Text.tsx
+++ b/packages/core/src/ui/Text.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, ReactNode } from 'react';
 import { StyleSheet, Text as OriginText, TextProps as OriginTextProps } from 'react-native';
-import { useOverride } from '@react-native-cask-ui/theme';
+import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
 import { $Diff } from 'utility-types';
 
 const defaultStyles = StyleSheet.create({

--- a/packages/core/src/ui/TextInput.tsx
+++ b/packages/core/src/ui/TextInput.tsx
@@ -7,7 +7,7 @@ import {
   TextInput as OriginTextInput,
   TextInputProps as OriginTextInputProps,
 } from 'react-native';
-import { useOverride, useMemoStyles, TColor } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/packages/core/src/ui/Toolbar.tsx
+++ b/packages/core/src/ui/Toolbar.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useOverride, useMemoStyles } from '@react-native-cask-ui/theme';
+import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {

--- a/storybook/.storybook/preview.js
+++ b/storybook/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ThemeProvider } from '@react-native-cask-ui/theme';
+import { ThemeProvider } from '@qubic-js/react-native-cask-ui-theme';
 
 import { themes } from '../theme';
 

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -7,7 +7,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@react-native-cask-ui/core": "*",
+    "@qubic-js/react-native-cask-ui-core": "*",
     "@storybook/react": "^6.0.21",
     "@storybook/react-native": "^5.3.21",
     "expo": "~38.0.8",

--- a/storybook/stories/components/Badge.stories.tsx
+++ b/storybook/stories/components/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge, BadgeProps } from '@react-native-cask-ui/core';
+import { Badge, BadgeProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 export default {

--- a/storybook/stories/components/Button.stories.tsx
+++ b/storybook/stories/components/Button.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonProps } from '@react-native-cask-ui/core';
+import { Button, ButtonProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 import Feather from 'react-native-vector-icons/Feather';
 

--- a/storybook/stories/components/ButtonNext.stories.tsx
+++ b/storybook/stories/components/ButtonNext.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { ButtonNext as Button, ButtonNextProps as ButtonProps } from '@react-native-cask-ui/core';
+import { ButtonNext as Button, ButtonNextProps as ButtonProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 import Feather from 'react-native-vector-icons/Feather';
 

--- a/storybook/stories/components/Card.stories.tsx
+++ b/storybook/stories/components/Card.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardProps, Text } from '@react-native-cask-ui/core';
+import { Card, CardProps, Text } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 export default {

--- a/storybook/stories/components/Image.stories.tsx
+++ b/storybook/stories/components/Image.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, ImageProps } from '@react-native-cask-ui/core';
+import { Image, ImageProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 import TaipeiImage from '../assets/img_taipei.jpg';

--- a/storybook/stories/components/List.stories.tsx
+++ b/storybook/stories/components/List.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import { List, ListProps, ListItem, AccessoryType } from '@react-native-cask-ui/core';
+import { List, ListProps, ListItem, AccessoryType } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 const data = [1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => `Item ${i}`);

--- a/storybook/stories/components/Text.stories.tsx
+++ b/storybook/stories/components/Text.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TextProps } from '@react-native-cask-ui/core';
+import { Text, TextProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 const LONG_TEXT =

--- a/storybook/stories/components/TextInput.stories.tsx
+++ b/storybook/stories/components/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextInput, TextInputProps } from '@react-native-cask-ui/core';
+import { TextInput, TextInputProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 export default {

--- a/storybook/stories/guideline/Typography.stories.mdx
+++ b/storybook/stories/guideline/Typography.stories.mdx
@@ -1,4 +1,4 @@
-import { Text, TextProps } from '@react-native-cask-ui/core';
+import { Text, TextProps } from '@qubic-js/react-native-cask-ui-core';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 
 <Meta title="Guideline/Typography" />

--- a/storybook/stories/layouts/Flex.stories.tsx
+++ b/storybook/stories/layouts/Flex.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Flex, FlexProps } from '@react-native-cask-ui/core';
+import { Flex, FlexProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 export default {

--- a/storybook/stories/layouts/Stack.stories.tsx
+++ b/storybook/stories/layouts/Stack.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Stack, StackProps } from '@react-native-cask-ui/core';
+import { Stack, StackProps } from '@qubic-js/react-native-cask-ui-core';
 import { Story, Meta } from '@storybook/react';
 
 export default {

--- a/storybook/theme/light/index.ts
+++ b/storybook/theme/light/index.ts
@@ -1,4 +1,4 @@
-import { Theme } from '@react-native-cask-ui/theme';
+import { Theme } from '@qubic-js/react-native-cask-ui-theme';
 
 import palette from './palette';
 import overrides from './overrides';

--- a/storybook/theme/light/overrides.ts
+++ b/storybook/theme/light/overrides.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { Overrides } from '@react-native-cask-ui/theme';
+import { Overrides } from '@qubic-js/react-native-cask-ui-theme';
 
 import palette from './palette';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "declaration": true,
     "baseUrl": ".",
     "paths": {
-      "@react-native-cask-ui/*": ["./packages/*/src"]
+      "@qubic-js/react-native-cask-ui-core": ["./packages/core/src"],
+      "@qubic-js/react-native-cask-ui-theme": ["./packages/theme/src"]
     },
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,28 +3449,6 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-native-cask-ui/core@*":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@react-native-cask-ui/core/-/core-1.1.0.tgz#1ed94193be628af179375ed122413fff9d1a313c"
-  integrity sha512-56iy9EaXmM4UkHyWHspy5xQsQPCoY+FRE/+udUjzkJZM0iiItMWEX6g3LEN6iuInldQmXfSM9BrAIpNTtirR9g==
-  dependencies:
-    "@react-native-cask-ui/theme" "^1.0.3"
-    react-content-loader "^5.1.2"
-    react-native-draggable-flatlist "^1.1.9"
-    react-native-safe-area-context "4.4.1"
-    react-native-svg "12.1.0"
-    react-native-svg-web "^1.0.9"
-    react-native-tab-view "2.14.3"
-    react-navigation-header-buttons "^3.0.1"
-    utility-types "^3.10.0"
-
-"@react-native-cask-ui/theme@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@react-native-cask-ui/theme/-/theme-1.0.3.tgz#9ba2a7c2a99f42b72de80a67039c9b9524b2f455"
-  integrity sha512-2duPXaOl7cN0IuNfVdK8Rvd9d3KWZ3DS3MnyxofRC/p8NUuR03kkjXhi/Xyk0tZTqM/y3pFPZouSYRUbYq8Q4w==
-  dependencies:
-    shallow-equal "^1.2.1"
-
 "@react-native-community/cli-clean@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-11.3.10.tgz#70d14dd998ce8ad532266b36a0e5cafe22d300ac"


### PR DESCRIPTION
先前的版本其實很多地方都還是指向原本的 cask-ui
這個 PR 中一次性的全部改為使用 monorepo 內部的 package