### PR TITLE
[ASL-6138] Resolve console warning and remove unused draggable-flatlist

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@qubic-js/react-native-cask-ui-theme": "^1.4.2",
     "react-content-loader": "^5.1.2",
-    "react-native-draggable-flatlist": "^1.1.9",
     "react-native-safe-area-context": "4.8.2",
     "react-native-svg": "14.1.0",
     "react-navigation-header-buttons": "^3.0.1",
@@ -28,7 +27,6 @@
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/react-native": "^0.63.19",
-    "@types/react-native-draggable-flatlist": "^1.1.1",
     "@types/react-native-vector-icons": "^6.4.6",
     "react-native-svg-web": "^1.0.9"
   },

--- a/packages/core/src/ui/InputSpinner.tsx
+++ b/packages/core/src/ui/InputSpinner.tsx
@@ -22,7 +22,7 @@ const defaultStyles = StyleSheet.create({
   },
   text: {
     fontSize: 15,
-    fontVariant: ['tabular-nums'],
+    fontVariant: 'tabular-nums',
     lineHeight: 20,
     fontWeight: 'bold',
     marginHorizontal: 12,

--- a/packages/core/src/ui/List.tsx
+++ b/packages/core/src/ui/List.tsx
@@ -10,7 +10,6 @@ import {
   ListRenderItem,
   VirtualizedListWithoutRenderItemProps,
 } from 'react-native';
-import DraggableFlatList, { OnMoveEndInfo } from 'react-native-draggable-flatlist';
 import { useOverride, TStyle } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
@@ -65,23 +64,14 @@ export type SectionData<ItemT> =
 export interface ListProps<ItemT> extends VirtualizedListWithoutRenderItemProps<ItemT> {
   variant?: string;
   sectionType: 'plain' | 'grouped';
-  draggable?: boolean;
   renderSectionHeader?: (info: { section: SectionListData<ItemT> }, sectionHeader: ReactElement) => ReactElement | null;
   renderSectionFooter?: (info: { section: SectionListData<ItemT> }, sectionFooter: ReactElement) => ReactElement | null;
   renderItem: SectionListRenderItem<ItemT> | ListRenderItem<ItemT>;
   keyExtractor: (item: any, index: number) => string;
-  extraData?: unknown;
-  initialScrollIndex?: number;
   ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
   sections?: SectionData<ItemT>[] | null;
   data?: ItemT[] | null;
   contentContainerStyle?: TStyle;
-  scrollEnabled?: boolean;
-  // draggable
-  scrollPercent?: number;
-  onMoveEnd?: (info: OnMoveEndInfo<unknown>) => void;
-  onMoveBegin?: (index: number) => void;
-  stickySectionHeadersEnabled?: boolean;
 }
 
 function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }, ref: any): JSX.Element | null {
@@ -89,11 +79,11 @@ function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }
   const {
     contentContainerStyle,
     sectionType = 'plain',
-    draggable,
     sections,
     data,
     renderSectionHeader: originRenderSectionHeader,
     renderSectionFooter: originRenderSectionFooter,
+    renderItem,
     ...otherProps
   } = overridedProps;
 
@@ -205,6 +195,7 @@ function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }
             : {},
           contentContainerStyle,
         ]}
+        renderItem={renderItem as SectionListRenderItem<ItemT>}
         {...otherProps}
         ref={ref}
       />
@@ -214,14 +205,13 @@ function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }
   if (data) {
     // remove empty data
     const newData = data.filter(d => !!d);
-    const FlatListRenderer = draggable ? DraggableFlatList : FlatList;
 
     return (
-      /* @ts-ignore */
-      <FlatListRenderer
+      <FlatList
         data={newData}
         ItemSeparatorComponent={renderItemSeparator}
         contentContainerStyle={contentContainerStyle}
+        renderItem={renderItem as ListRenderItem<ItemT>}
         {...otherProps}
         ref={ref}
       />

--- a/packages/core/src/ui/ListItem.tsx
+++ b/packages/core/src/ui/ListItem.tsx
@@ -30,6 +30,7 @@ const defaultStyles = StyleSheet.create({
     paddingRight: 16,
     minHeight: 44,
     backgroundColor: 'white',
+    pointerEvents: 'box-only',
   },
   content: {
     flex: 1,
@@ -188,11 +189,7 @@ const ListItem = React.memo<ListItemProps>(props => {
         {text}
       </Text>
     );
-    touchableView = (
-      <View style={finalStyleForButton} pointerEvents="box-only">
-        {innerView}
-      </View>
-    );
+    touchableView = <View style={finalStyleForButton}>{innerView}</View>;
   } else {
     // icon
     const imageView = <IconImageView {...props} />;
@@ -210,7 +207,7 @@ const ListItem = React.memo<ListItemProps>(props => {
       </View>
     );
     touchableView = (
-      <View style={finalStyle} pointerEvents={allowsInnerPressable ? 'auto' : 'box-only'}>
+      <View style={[finalStyle, { pointerEvents: allowsInnerPressable ? 'auto' : 'box-only' }]}>
         {innerView}
         <AccessoryView {...props} />
       </View>

--- a/packages/core/src/ui/LoadingSpinner/LoadingSpinnerRenderer.tsx
+++ b/packages/core/src/ui/LoadingSpinner/LoadingSpinnerRenderer.tsx
@@ -33,7 +33,7 @@ export default React.memo<LoadingSpinnerRendererProps>(props => {
   const finalTextStyle = useMemoStyles([defaultStyles.text, styles.text]);
 
   return (
-    <View style={StyleSheet.absoluteFillObject} pointerEvents={hidden ? 'none' : 'auto'}>
+    <View style={[StyleSheet.absoluteFillObject, { pointerEvents: hidden ? 'none' : 'auto' }]}>
       {!hidden && (
         <View style={finalOverlayStyle}>
           <View style={finalToastStyle}>

--- a/packages/core/src/ui/Modal.tsx
+++ b/packages/core/src/ui/Modal.tsx
@@ -7,6 +7,7 @@ const defaultStyles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'white',
     opacity: 0.7,
+    pointerEvents: 'box-none',
   },
   modal: {
     width: '90%',
@@ -70,7 +71,7 @@ export default React.memo<TModalProps>(props => {
     <Modal visible={visible} animationType={animationType} transparent={transparent} onRequestClose={onDismiss}>
       <TouchableWithoutFeedback onPress={onDismiss}>
         <View style={fixedStyles.fill}>
-          <View style={finalBackdropStyle} pointerEvents="box-none" />
+          <View style={finalBackdropStyle} />
           <View style={fixedStyles.modalWrapper}>
             <TouchableWithoutFeedback>
               <View style={finalModalStyle}>

--- a/packages/core/src/ui/ReadMore.tsx
+++ b/packages/core/src/ui/ReadMore.tsx
@@ -9,6 +9,7 @@ const fixedStyles = StyleSheet.create({
     left: 0,
     right: 0,
     opacity: 0,
+    pointerEvents: 'none',
   },
   footer: {
     flexDirection: 'row',
@@ -57,18 +58,10 @@ export default React.memo<ReadMoreProps>(props => {
 
   return (
     <View>
-      <View
-        style={displayFullText ? fixedStyles.hidden : undefined}
-        pointerEvents={displayFullText ? 'none' : undefined}
-        onLayout={handleCollapsedTextLayout}
-      >
+      <View style={displayFullText ? fixedStyles.hidden : undefined} onLayout={handleCollapsedTextLayout}>
         <Text numberOfLines={numberOfLines}>{children}</Text>
       </View>
-      <View
-        style={!displayFullText ? fixedStyles.hidden : undefined}
-        pointerEvents={!displayFullText ? 'none' : undefined}
-        onLayout={handleFullTextLayout}
-      >
+      <View style={!displayFullText ? fixedStyles.hidden : undefined} onLayout={handleFullTextLayout}>
         <Text>{children}</Text>
       </View>
       {tooManyText && (

--- a/storybook/stories/Introduction.stories.mdx
+++ b/storybook/stories/Introduction.stories.mdx
@@ -73,7 +73,7 @@ import StackAlt from './assets/stackalt.svg';
     display: block;
     margin-bottom: 2px;
   }
-  
+
   .link-item img {
     height: 40px;
     width: 40px;
@@ -111,7 +111,7 @@ import StackAlt from './assets/stackalt.svg';
     display: inline-block;
   }
 
-  
+
 `}</style>
 
 # Welcome to Storybook
@@ -147,7 +147,11 @@ We recommend building UIs with a [**component-driven**](https://componentdriven.
       How to load and configure CSS libraries
     </span>
   </a>
-  <a class="link-item" href="https://storybook.js.org/docs/react/get-started/setup#configure-storybook-for-your-stack" target="_blank">
+  <a
+    class="link-item"
+    href="https://storybook.js.org/docs/react/get-started/setup#configure-storybook-for-your-stack"
+    target="_blank"
+  >
     <img src={Flow} alt="flow" />
     <span>
       <strong>Data</strong>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4758,14 +4758,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native-draggable-flatlist@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/react-native-draggable-flatlist/-/react-native-draggable-flatlist-1.1.1.tgz#81fa66d1f4899348195acfad6e23e33dec935a7b"
-  integrity sha512-E/dkV2QrPvDXvcDLGpBZmR1iDql20ph9zUjHpZ2heNA56+k5iTQP6NN5oVlLC7B3sFScntI57kn3ZiDBHVTDsQ==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-native" "*"
-
 "@types/react-native-vector-icons@^6.4.6":
   version "6.4.6"
   resolved "https://registry.yarnpkg.com/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.6.tgz#848e3b14572def56212cafbf5cb1254b445bfb41"
@@ -15469,11 +15461,6 @@ react-native-appearance@~0.3.3:
     fbemitter "^2.1.1"
     invariant "^2.2.4"
     use-subscription "^1.0.0"
-
-react-native-draggable-flatlist@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/react-native-draggable-flatlist/-/react-native-draggable-flatlist-1.1.9.tgz#b8f58122f639841c83aa1d913b2e3e9f9507bfe5"
-  integrity sha512-Hga/kEFc+Undx2Y1FzkozWHRWvRz7dJobl5Kg1+xmd9JABS8YIYZWKboSAPmiTHD3FrlVJGIw/mlK5JZP0rJfw==
 
 react-native-gesture-handler@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
處理部分開發模式的警告

- 移除沒用到的 `react-native-draggable-flatlist` (Qubic Wallet 沒有使用到，可避免 YellowBox 的警告)
- `fontVariant` 改用 string type
- View `props.pointerEvents` 移動到 style 內
