### PR TITLE
[ASL-6625] add ComponentVariants for variant type replacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,67 @@ $ yarn storybook
 ### Important
 
 **DON'T** use `defaultProps` for any UI Component. It will break the `overrides` effect.
+
+### How to set overrides
+
+overrides should be something like this
+
+```
+const overrides = {
+  Badge: {
+    default: {
+      props: {
+        color: palette.primaryColor,
+      },
+      styles: StyleSheet.create({
+        text: {
+          color: 'white',
+        },
+      }),
+    },
+    slim: {
+      styles: StyleSheet.create({
+        badge: {
+          ...someProps,
+        },
+        text: {
+          fontSize: 13,
+        },
+      }),
+    },
+  },
+  Button: {
+    ...someProps,
+  },
+  Card: {
+    ...
+  },
+  ...
+}
+```
+
+check /storybook/theme/light/overrides.ts for example
+
+### How to add variant
+
+
+
+make sure your override object is "as const" literal typed
+```
+import { ExtractVariantKeys } from '@qubic-js/react-native-cask-ui-theme';
+const overrides = {...} as const;
+type ComponentVariantKeys = ExtractVariantKeys<overrides>;
+```
+
+if overrides is a function, make sure to `ReturnType<typeof overrides>`
+```
+const getOverrides = (palette) => {...} as const;
+type ComponentVariantKeys = ExtractVariantKeys<ReturnType<typeof getOverrides>>;
+```
+
+create a theme.d.ts
+```
+declare module '@qubic-js/react-native-cask-ui-theme' {
+  interface ComponentVariants extends ComponentVariantKeys {}
+}
+```

--- a/packages/core/src/ui-next/Button.tsx
+++ b/packages/core/src/ui-next/Button.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { StyleSheet, TouchableOpacity, View, Text } from 'react-native';
 import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
-import { $Diff } from 'utility-types';
 
 import type { TouchableOpacityProps, ViewStyle, TextStyle, ImageStyle } from 'react-native';
 
@@ -90,7 +89,7 @@ const defaultStyles = StyleSheet.create({
   textDisabled: {},
 });
 
-export interface ButtonProps extends $Diff<TouchableOpacityProps, { style?: unknown; children?: unknown }> {
+export interface ButtonProps extends Omit<TouchableOpacityProps, 'style' | 'children'> {
   /**
    * The variant to use.
    */

--- a/packages/core/src/ui/Badge.tsx
+++ b/packages/core/src/ui/Badge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
-import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, TColor, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -22,7 +22,7 @@ export interface BadgeProps {
   /**
    * The variant to use.
    */
-  variant?: string;
+  variant?: ComponentVariant<'Badge'>;
   /**
    * The color the badge backgroud.
    */

--- a/packages/core/src/ui/Button.tsx
+++ b/packages/core/src/ui/Button.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { StyleSheet, TouchableOpacity, View, Text, TouchableOpacityProps } from 'react-native';
-import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
-import { $Diff } from 'utility-types';
+import { useOverride, useMemoStyles, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -28,11 +27,11 @@ const defaultStyles = StyleSheet.create({
   textDisabled: {},
 });
 
-export interface LegacyButtonProps extends $Diff<TouchableOpacityProps, { style?: unknown; children?: unknown }> {
+export interface LegacyButtonProps extends Omit<TouchableOpacityProps, 'style' | 'children'> {
   /**
    * The variant to use.
    */
-  variant?: string;
+  variant?: ComponentVariant<'Button'>;
   /**
    * The icon beside the button title. Usually be placed on the left side.
    */

--- a/packages/core/src/ui/Card.tsx
+++ b/packages/core/src/ui/Card.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -25,7 +25,7 @@ export interface CardProps {
   /**
    * The variant to use.
    */
-  variant?: string;
+  variant?: ComponentVariant<'Card'>;
   /**
    * Anything inside the card.
    */

--- a/packages/core/src/ui/HeaderButtons.tsx
+++ b/packages/core/src/ui/HeaderButtons.tsx
@@ -5,10 +5,10 @@ import {
   HeaderItemProps,
 } from 'react-navigation-header-buttons';
 import EvilIcons from '@expo/vector-icons/EvilIcons';
-import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 export type HeaderButtonsItemProps = {
-  variant?: string;
+  variant?: ComponentVariant<'HeaderButtons'>;
   title: string;
   iconName?: string;
   iconAliases?: {
@@ -38,7 +38,7 @@ const HeaderButtonsItem = React.memo<HeaderButtonsItemProps>(props => {
 });
 
 export type HeaderButtonsProps = {
-  variant?: string;
+  variant?: ComponentVariant<'HeaderButtons'>;
   children: ReactNode;
 };
 

--- a/packages/core/src/ui/Image.tsx
+++ b/packages/core/src/ui/Image.tsx
@@ -12,8 +12,7 @@ import {
 import ContentLoader from 'react-content-loader';
 import { Path } from 'react-native-svg';
 // import * as Progress from 'react-native-progress';
-import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
-import { $Diff } from 'utility-types';
+import { useOverride, useMemoStyles, TColor, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -41,12 +40,12 @@ const fixedStyles = StyleSheet.create({
   },
 });
 
-export interface ImageProps extends $Diff<OriginImageProps, { source: ImageSourcePropType }> {
+export interface ImageProps extends Omit<OriginImageProps, 'source'> {
   ImageRenderer?: ReactNode;
   /**
    * The variant to use.
    */
-  variant?: string;
+  variant?: ComponentVariant<'Image'>;
   /**
    * The image element or remote url.
    */

--- a/packages/core/src/ui/InputSpinner.tsx
+++ b/packages/core/src/ui/InputSpinner.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback } from 'react';
 import { StyleSheet, View, TouchableOpacity, Text } from 'react-native';
 import EvilIcons from '@expo/vector-icons/EvilIcons';
-import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -36,7 +36,7 @@ type Option = {
 
 export type TInputSpinnerProps = {
   // eslint-disable-next-line react/no-unused-prop-types
-  variant?: string;
+  variant?: ComponentVariant<'InputSpinner'>;
   options: Array<Option>;
   value: any;
   onValueChange: (value: any) => void;

--- a/packages/core/src/ui/List.tsx
+++ b/packages/core/src/ui/List.tsx
@@ -10,7 +10,7 @@ import {
   ListRenderItem,
   VirtualizedListWithoutRenderItemProps,
 } from 'react-native';
-import { useOverride, TStyle } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, TStyle, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   defaultHeaderPlaceholder: {
@@ -61,7 +61,7 @@ export type SectionData<ItemT> =
   | null;
 
 export interface ListProps<ItemT> extends VirtualizedListWithoutRenderItemProps<ItemT> {
-  variant?: string;
+  variant?: ComponentVariant<'List'>;
   sectionType: 'plain' | 'grouped';
   renderSectionHeader?: (info: { section: SectionListData<ItemT> }, sectionHeader: ReactElement) => ReactElement | null;
   renderSectionFooter?: (info: { section: SectionListData<ItemT> }, sectionFooter: ReactElement) => ReactElement | null;
@@ -73,7 +73,10 @@ export interface ListProps<ItemT> extends VirtualizedListWithoutRenderItemProps<
   contentContainerStyle?: TStyle;
 }
 
-function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }, ref: any): JSX.Element | null {
+// List 組件的 ref 可以是 FlatList 或 SectionList，取決於是否使用 sections
+export type ListRef<ItemT = unknown> = FlatList<ItemT> | SectionList<ItemT>;
+
+function ListBase<ItemT>(props: ListProps<ItemT>, ref: React.Ref<ListRef<ItemT>>): JSX.Element | null {
   const { props: overridedProps, styles } = useOverride<ListProps<ItemT>>('List', props);
   const {
     contentContainerStyle,
@@ -196,7 +199,7 @@ function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }
         ]}
         renderItem={renderItem as SectionListRenderItem<ItemT>}
         {...otherProps}
-        ref={ref}
+        ref={ref as React.Ref<SectionList<ItemT>>}
       />
     );
   }
@@ -212,7 +215,7 @@ function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }
         contentContainerStyle={contentContainerStyle}
         renderItem={renderItem as ListRenderItem<ItemT>}
         {...otherProps}
-        ref={ref}
+        ref={ref as React.Ref<FlatList<ItemT>>}
       />
     );
   }
@@ -220,6 +223,8 @@ function ListBase<ItemT>(props: ListProps<ItemT> & { ref?: React.Ref<FlatList> }
   return null;
 }
 
-const List = React.memo(React.forwardRef(ListBase)) as typeof ListBase;
+const List = React.memo(React.forwardRef(ListBase)) as <ItemT>(
+  props: ListProps<ItemT> & { ref?: React.Ref<ListRef<ItemT>> },
+) => JSX.Element | null;
 
 export default List;

--- a/packages/core/src/ui/ListItem.tsx
+++ b/packages/core/src/ui/ListItem.tsx
@@ -13,7 +13,7 @@ import {
   KeyboardTypeOptions,
 } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, TColor, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 import DisclosureIndicator from '../svg/DisclosureIndicator';
 
@@ -116,7 +116,7 @@ const fixedStyle = StyleSheet.create({
 });
 
 export type ListItemProps = {
-  variant?: string;
+  variant?: ComponentVariant<'ListItem'>;
   // props
   onPress?: (e: GestureResponderEvent, extra: any) => void;
   disabled?: boolean;

--- a/packages/core/src/ui/LoadingSpinner/types.ts
+++ b/packages/core/src/ui/LoadingSpinner/types.ts
@@ -1,8 +1,8 @@
 import { ComponentType } from 'react';
-import { TColor } from '@qubic-js/react-native-cask-ui-theme';
+import { TColor, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 type BaseProps = {
-  variant?: string;
+  variant?: ComponentVariant<'LoadingSpinner'>;
   color?: TColor;
   size?: number | 'small' | 'large';
 };

--- a/packages/core/src/ui/Modal.tsx
+++ b/packages/core/src/ui/Modal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { StyleSheet, View, Modal, TouchableWithoutFeedback, NativeSyntheticEvent } from 'react-native';
-import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   backdrop: {
@@ -43,7 +43,7 @@ const fixedStyles = StyleSheet.create({
 });
 
 export type TModalProps = {
-  variant?: string;
+  variant?: ComponentVariant<'Modal'>;
   animationType?: 'none' | 'slide' | 'fade';
   transparent?: boolean;
   visible?: boolean;

--- a/packages/core/src/ui/Rating.tsx
+++ b/packages/core/src/ui/Rating.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Text, TouchableOpacity, DimensionValue } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -22,7 +22,7 @@ const defaultStyles = StyleSheet.create({
 });
 
 export type RatingProps = {
-  variant?: string;
+  variant?: ComponentVariant<'Rating'>;
   value: number;
   maxValue?: number;
   iconSize?: number;

--- a/packages/core/src/ui/Screen.tsx
+++ b/packages/core/src/ui/Screen.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useMemo } from 'react';
 import { StyleSheet, View, StatusBar, StatusBarStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useOverride, useMemoStyles, TStyle } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, TStyle, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -53,7 +53,7 @@ const SafeAreaView = (props: SafeAreaViewProps) => {
 };
 
 export interface ScreenProps {
-  variant?: string;
+  variant?: ComponentVariant<'Screen'>;
   topSafe?: boolean;
   bottomSafe?: boolean;
   statusBar?: {

--- a/packages/core/src/ui/SearchBar/types.ts
+++ b/packages/core/src/ui/SearchBar/types.ts
@@ -1,10 +1,10 @@
 import { ComponentType } from 'react';
 import { KeyboardTypeOptions, NativeSyntheticEvent, TextInputFocusEventData } from 'react-native';
 
-import { TColor } from '@qubic-js/react-native-cask-ui-theme';
+import { TColor, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 type BaseProps = {
-  variant?: string;
+  variant?: ComponentVariant<'SearchBar'>;
   value?: string;
   placeholder?: string;
   autoCorrect?: boolean;

--- a/packages/core/src/ui/Separator.tsx
+++ b/packages/core/src/ui/Separator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -10,7 +10,7 @@ const defaultStyles = StyleSheet.create({
 });
 
 export type SeparatorProps = {
-  variant?: string;
+  variant?: ComponentVariant<'Separator'>;
 };
 
 export default React.memo<SeparatorProps>(props => {

--- a/packages/core/src/ui/Text.tsx
+++ b/packages/core/src/ui/Text.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, ReactNode } from 'react';
 import { StyleSheet, Text as OriginText, TextProps as OriginTextProps } from 'react-native';
-import { useOverride } from '@qubic-js/react-native-cask-ui-theme';
-import { $Diff } from 'utility-types';
+import { useOverride, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   text: {
@@ -10,11 +9,11 @@ const defaultStyles = StyleSheet.create({
   },
 });
 
-export interface TextProps extends $Diff<OriginTextProps, { style?: unknown }> {
+export interface TextProps extends Omit<OriginTextProps, 'style'> {
   /**
    * The variant to use.
    */
-  variant?: string;
+  variant?: ComponentVariant<'Text'>;
   /**
    * The text alignment.
    */
@@ -23,13 +22,9 @@ export interface TextProps extends $Diff<OriginTextProps, { style?: unknown }> {
    * The text to display or nested Text components.
    */
   children: ReactNode;
-  /**
-   * The ref to text.
-   */
-  ref?: React.Ref<OriginText> | undefined;
 }
 
-const Text = React.forwardRef<OriginText, TextProps>((props, ref) => {
+const Text = React.forwardRef<React.ElementRef<typeof OriginText>, TextProps>((props, ref) => {
   const { props: overridedProps, styles } = useOverride('Text', props);
   const { textAlign, children, ...otherProps } = overridedProps;
 

--- a/packages/core/src/ui/TextInput.tsx
+++ b/packages/core/src/ui/TextInput.tsx
@@ -1,4 +1,3 @@
-import { $Diff } from 'utility-types';
 import React from 'react';
 import {
   StyleSheet,
@@ -7,7 +6,7 @@ import {
   TextInput as OriginTextInput,
   TextInputProps as OriginTextInputProps,
 } from 'react-native';
-import { useOverride, useMemoStyles, TColor } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, TColor, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -30,12 +29,11 @@ const defaultStyles = StyleSheet.create({
   textInputDisabled: {},
 });
 
-export interface TextInputProps extends $Diff<OriginTextInputProps, { style?: unknown; children?: unknown }> {
-  ref?: any;
+export interface TextInputProps extends Omit<OriginTextInputProps, 'style' | 'children'> {
   /**
    * The variant to use.
    */
-  variant?: string;
+  variant?: ComponentVariant<'TextInput'>;
   /**
    * The label above the text input control.
    */
@@ -58,7 +56,7 @@ export interface TextInputProps extends $Diff<OriginTextInputProps, { style?: un
   editable?: boolean;
 }
 
-const TextInput = React.forwardRef<OriginTextInput, TextInputProps>((props, ref) => {
+const TextInput = React.forwardRef<React.ElementRef<typeof OriginTextInput>, TextInputProps>((props, ref) => {
   const { props: overridedProps, styles } = useOverride('TextInput', props);
   const { label, editable, ...otherProps } = overridedProps;
 

--- a/packages/core/src/ui/Toolbar.tsx
+++ b/packages/core/src/ui/Toolbar.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { useOverride, useMemoStyles } from '@qubic-js/react-native-cask-ui-theme';
+import { useOverride, useMemoStyles, ComponentVariant } from '@qubic-js/react-native-cask-ui-theme';
 
 const defaultStyles = StyleSheet.create({
   root: {
@@ -12,7 +12,7 @@ const defaultStyles = StyleSheet.create({
 });
 
 export type ToolbarProps = {
-  variant?: string;
+  variant?: ComponentVariant<'Toolbar'>;
   location?: 'top' | 'bottom';
   children: ReactNode;
 };

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -24,10 +24,21 @@ export type TOverrideConfig<TProps> = {
   };
 };
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ComponentVariants {
+  // Default empty, allows users to extend via declare module
+}
+
 export type Overrides<TProps = unknown> = {
   [componentName: string]: {
     [variantName: string]: TOverrideConfig<TProps>;
   };
+};
+
+export type ComponentVariant<T extends string> = T extends keyof ComponentVariants ? ComponentVariants[T] : string;
+
+export type ExtractVariantKeys<T> = {
+  [K in keyof T]: Exclude<keyof T[K], 'default'>;
 };
 
 export type ThemeName = 'light' | 'dark';


### PR DESCRIPTION
幫所有 Variant (除了新的 Button 除外) 加上了 variant 可以根據 ComponentVariants 的設定去限制 literal type
如果 ComponentVariants 裡沒有包含某種 component 則會自動 fallback variant?: string